### PR TITLE
Update WooWorker.js

### DIFF
--- a/src/WooCommerce/WooWorker.js
+++ b/src/WooCommerce/WooWorker.js
@@ -242,9 +242,10 @@ export default class WooWorker {
       console.log(err);
     }
   };
-  static getShippingMethod = async () => {
+  static getShippingMethod = async zoneId => {
+    zoneId = zoneId || 1;
     try {
-      const response = await this._api.get("shipping/zones/1/methods");
+      const response = await this._api.get("shipping/zones/" + zoneId + "/methods");
       return response.json();
     } catch (err) {
       console.log(err);


### PR DESCRIPTION
This patch allow us to specify shipping zone ID when using WooWorker, this way it is more flexible for developers and not hardcoded.